### PR TITLE
F1: Copilot Review Follow-Up

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -155,20 +155,20 @@ metadata:
     }
 
     #[test]
-    fn field_accessors_name_and_description() {
+    fn field_access_name_and_description() {
         let sp = minimal_props();
         assert_eq!(sp.name, "foo");
         assert_eq!(sp.description, "bar");
     }
 
     #[test]
-    fn field_accessor_allowed_tools() {
+    fn field_access_allowed_tools() {
         let sp = full_props();
         assert_eq!(sp.allowed_tools.as_deref(), Some("Bash, Read"));
     }
 
     #[test]
-    fn field_accessor_metadata() {
+    fn field_access_metadata() {
         let sp = full_props();
         let meta = sp.metadata.as_ref().unwrap();
         assert_eq!(


### PR DESCRIPTION
## Summary

- Rename 3 test functions in `src/models.rs`: `field_accessor(s)_*` → `field_access_*` to align with Rust terminology (direct field access, not accessor methods)
- Addresses valid Copilot review comments on PR #39

## Changes

| File | Change |
|------|--------|
| `src/models.rs` | `field_accessors_name_and_description` → `field_access_name_and_description` |
| `src/models.rs` | `field_accessor_allowed_tools` → `field_access_allowed_tools` |
| `src/models.rs` | `field_accessor_metadata` → `field_access_metadata` |

PR #43 Copilot comment (`.trim()` on predicate) is a false positive — response posted on the PR.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 170 tests pass (146 unit + 23 integration + 1 doc-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)