### PR TITLE
Move build matrix table from CI to release section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1332,7 +1332,7 @@ This single command:
 2. Generates a changelog from merged PRs since the previous tag (via `gh`)
 3. Writes the changelog to `CHANGES.md`
 4. Updates version across all files (`Cargo.toml`, `plugin.json`, `README.md`, `Cargo.lock`)
-5. Commits, tags, and pushes — triggering the CI release workflow
+5. Commits, tags, and pushes — triggering the release workflow
 
 Use `--dry-run` to preview without executing:
 


### PR DESCRIPTION
## Summary

- CI section: simplified to "three OSes" (no architecture table — CI runs one arch per OS)
- Release section: moved the 5-target architecture table here where it belongs

Closes #119.

## Test plan

- [x] Visual inspection of README sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)