### PR TITLE
Clarify expect() policy for static regex initializers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ cargo fmt --check                   # Check formatting
 
 - Idiomatic Rust: use `Result<T, E>`, pattern matching, iterators
 - No `unwrap()` or `expect()` in `src/lib.rs` and modules — propagate errors with `?`
+- `expect()` allowed in static initializers (e.g., `LazyLock<Regex>`) for compile-time invariants
 - `unwrap()` allowed in tests and `main.rs` for known-safe operations
 - `#[must_use]` on functions returning values that shouldn't be ignored
 - Public items must have doc comments (`///`)


### PR DESCRIPTION
## Summary

- Add CLAUDE.md policy exception: `expect()` allowed in static initializers (e.g., `LazyLock<Regex>`) for compile-time invariants
  Closes #160

All 10 `expect()` calls in library code are in `LazyLock<Regex>` initializers with hardcoded patterns that cannot fail at runtime. This is standard Rust practice for static regex compilation. The policy's intent (prevent panics from user input / I/O) is already satisfied — zero `unwrap()` in library code.

## Test plan

- [x] `cargo test` — all 692 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Verify CLAUDE.md wording is clear and scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)